### PR TITLE
Implement support for whitelists, default-deny/allow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ fmt.Println(f.AddrBlocked(lanaddr))
 
 // the default for a filter is accept, but we can change that
 f.Remove(ipnet)
-f.filterDefault = true
+f.RejectByDefault = true
 fmt.Println(f.AddrBlocked(lanaddr))
 
 // we can now allow the local LAN, denying everything else

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ f.AddDialFilter(ipnet)
 // check if an address is blocked
 lanaddr, _ := ma.NewMultiaddr("/ip4/192.168.0.17/tcp/4050")
 fmt.Println(f.AddrBlocked(lanaddr))
+
+// the default for a filter is accept, but we can change that
+f.Remove(ipnet)
+f.filterDefault = true
+fmt.Println(f.AddrBlocked(lanaddr))
+
+// we can now allow the local LAN, denying everything else
+f.AddAllowFilter(ipnet)
+fmt.Println(f.AddrBlocked(lanaddr))
 ```
 
 ## Contribute

--- a/filter.go
+++ b/filter.go
@@ -89,7 +89,8 @@ func (f *Filters) Remove(ff *net.IPNet) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	for idx := f.find(ff); idx != -1; idx = f.find(ff) {
+	idx := f.find(ff)
+	if idx != -1 {
 		f.filters = append(f.filters[:idx], f.filters[idx+1:]...)
 	}
 }

--- a/filter.go
+++ b/filter.go
@@ -57,8 +57,8 @@ func (fs *Filters) AddAllowFilter(f *net.IPNet) {
 	fs.filters = append(fs.filters, &filterEntry{f: f, reject: false})
 }
 
-// AddrBlocked parses a ma.Multiaddr, and if it can get a valid netip
-// back applies the Filters, returning true if the given address
+// AddrBlocked parses a ma.Multiaddr and, if it can get a valid netip
+// back, applies the Filters returning true if the given address
 // should be rejected, and false if the given address is allowed.
 //
 // If a parsing error occurs, or no filter matches, the Filters

--- a/filter.go
+++ b/filter.go
@@ -80,6 +80,20 @@ func (fs *Filters) AddAllowFilter(f *net.IPNet) {
 	}
 }
 
+// Remove removes all net.IPNet's accept/reject rule(s) from the
+// Filters, if there are matching rules.
+//
+// Makes no distinction between whether the rule is an allow or a
+// deny.
+func (f *Filters) Remove(ff *net.IPNet) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for idx := f.find(ff); idx != -1; idx = f.find(ff) {
+		f.filters = append(f.filters[:idx], f.filters[idx+1:]...)
+	}
+}
+
 // AddrBlocked parses a ma.Multiaddr and, if it can get a valid netip
 // back, applies the Filters returning true if the given address
 // should be rejected, and false if the given address is allowed.
@@ -139,18 +153,4 @@ func (f *Filters) AllowFilters() []*net.IPNet {
 		}
 	}
 	return out
-}
-
-// Remove removes all net.IPNet's accept/reject rule(s) from the
-// Filters, if there are matching rules.
-//
-// Makes no distinction between whether the rule is an allow or a
-// deny.
-func (f *Filters) Remove(ff *net.IPNet) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	for idx := f.find(ff); idx != -1; idx = f.find(ff) {
-		f.filters = append(f.filters[:idx], f.filters[idx+1:]...)
-	}
 }

--- a/filter.go
+++ b/filter.go
@@ -8,55 +8,80 @@ import (
 	manet "github.com/multiformats/go-multiaddr-net"
 )
 
-type FilterEntry struct {
+type filterEntry struct {
 	f      *net.IPNet
 	reject bool
 }
 
+// Filters is a structure representing a collection of allow/deny
+// net.IPNet filters, together with the RejectByDefault flag, which
+// represents the default filter policy.
+//
+// Note that the last policy added to the Filters is authoritative.
 type Filters struct {
-	mu            sync.RWMutex
-	filterDefault bool
-	filters       []*FilterEntry
+	mu              sync.RWMutex
+	RejectByDefault bool
+	filters         []*filterEntry
 }
 
+// NewFilters constructs and returns a new set of net.IPNet filters.
+// By default, the new filter rejects no addresses.
 func NewFilters() *Filters {
 	return &Filters{
-		filterDefault: false,
-		filters:       make([]*FilterEntry, 0),
+		RejectByDefault: false,
+		filters:         make([]*filterEntry, 0),
 	}
 }
 
+// AddDialFilter adds a reject rule to the given Filters.  Hosts
+// matching the given net.IPNet filter will be rejected, unless
+// another rule is added which states that they should be accepted.
+//
+// No effort is made to prevent duplication of filters, or to simplify
+// the filters list.
 func (fs *Filters) AddDialFilter(f *net.IPNet) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
-	fs.filters = append(fs.filters, &FilterEntry{f: f, reject: true})
+	fs.filters = append(fs.filters, &filterEntry{f: f, reject: true})
 }
 
+// AddAllowFilter adds an accept rule to the given Filters. Hosts
+// matching the given net.IPNet filter will be accepted, unless
+// another policy is added which states that they should be rejected.
+//
+// No effort is made to prevent duplication of filters, or to simplify
+// the filters list.
 func (fs *Filters) AddAllowFilter(f *net.IPNet) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
-	fs.filters = append(fs.filters, &FilterEntry{f: f, reject: false})
+	fs.filters = append(fs.filters, &filterEntry{f: f, reject: false})
 }
 
+// AddrBlocked parses a ma.Multiaddr, and if it can get a valid netip
+// back applies the Filters, returning true if the given address
+// should be rejected, and false if the given address is allowed.
+//
+// If a parsing error occurs, or no filter matches, the Filters
+// default is returned.
 func (f *Filters) AddrBlocked(a ma.Multiaddr) bool {
 	maddr := ma.Split(a)
 	if len(maddr) == 0 {
-		return false
+		return f.RejectByDefault
 	}
 	netaddr, err := manet.ToNetAddr(maddr[0])
 	if err != nil {
 		// if we cant parse it, its probably not blocked
-		return false
+		return f.RejectByDefault
 	}
 	netip := net.ParseIP(netaddr.String())
 	if netip == nil {
-		return false
+		return f.RejectByDefault
 	}
 
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	var reject bool = f.filterDefault
+	var reject bool = f.RejectByDefault
 
 	for _, ft := range f.filters {
 		if ft.f.Contains(netip) {
@@ -67,6 +92,11 @@ func (f *Filters) AddrBlocked(a ma.Multiaddr) bool {
 	return reject
 }
 
+// Filters returns the list of net.IPNet structs in the given filter
+// rules.
+//
+// FIXME: This function doesn't really make any sense now that filters
+// can be both positive and negative.
 func (f *Filters) Filters() []*net.IPNet {
 	var out []*net.IPNet
 	f.mu.RLock()
@@ -77,11 +107,16 @@ func (f *Filters) Filters() []*net.IPNet {
 	return out
 }
 
+// Find returns the index of a given net.IPNet filter in the Filters
+// rule lists, or -1 if there is no such filter.
+//
+// Used to implement deletion. Makes no attempt to recognize other
+// filters which would match the same netmask.
 func (f *Filters) Find(ff *net.IPNet) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	ffs := ff.String()
 
+	ffs := ff.String()
 	for idx, ft := range f.filters {
 		if ft.f.String() == ffs {
 			return idx
@@ -91,12 +126,16 @@ func (f *Filters) Find(ff *net.IPNet) int {
 	return -1
 }
 
+// Remove removes a single net.IPNet's accept/reject rule(s) from the
+// Filters, if there is matching rule.
+//
+// Makes no distinction between whether the rule is an allow or a
+// deny.
 func (f *Filters) Remove(ff *net.IPNet) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	idx := f.Find(ff)
-	if idx != -1 {
+	for idx := f.Find(ff); idx != -1; idx = f.Find(ff) {
 		f.filters = append(f.filters[:idx], f.filters[idx+1:]...)
 	}
 }

--- a/filter.go
+++ b/filter.go
@@ -107,15 +107,7 @@ func (f *Filters) Filters() []*net.IPNet {
 	return out
 }
 
-// Find returns the index of a given net.IPNet filter in the Filters
-// rule lists, or -1 if there is no such filter.
-//
-// Used to implement deletion. Makes no attempt to recognize other
-// filters which would match the same netmask.
-func (f *Filters) Find(ff *net.IPNet) int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
+func (f *Filters) find(ff *net.IPNet) int {
 	ffs := ff.String()
 	for idx, ft := range f.filters {
 		if ft.f.String() == ffs {
@@ -135,7 +127,7 @@ func (f *Filters) Remove(ff *net.IPNet) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	for idx := f.Find(ff); idx != -1; idx = f.Find(ff) {
+	for idx := f.find(ff); idx != -1; idx = f.find(ff) {
 		f.filters = append(f.filters[:idx], f.filters[idx+1:]...)
 	}
 }

--- a/filter.go
+++ b/filter.go
@@ -92,17 +92,28 @@ func (f *Filters) AddrBlocked(a ma.Multiaddr) bool {
 	return reject
 }
 
-// Filters returns the list of net.IPNet structs in the given filter
-// rules.
-//
-// FIXME: This function doesn't really make any sense now that filters
-// can be both positive and negative.
+// Filters returns the list of DENY net.IPNet masks
 func (f *Filters) Filters() []*net.IPNet {
 	var out []*net.IPNet
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	for _, ff := range f.filters {
-		out = append(out, ff.f)
+		if ff.reject {
+			out = append(out, ff.f)
+		}
+	}
+	return out
+}
+
+// AllowFilters returns the list of ALLOW net.IPNet masks
+func (f *Filters) AllowFilters() []*net.IPNet {
+	var out []*net.IPNet
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, ff := range f.filters {
+		if !ff.reject {
+			out = append(out, ff.f)
+		}
 	}
 	return out
 }

--- a/filter.go
+++ b/filter.go
@@ -126,8 +126,8 @@ func (f *Filters) Find(ff *net.IPNet) int {
 	return -1
 }
 
-// Remove removes a single net.IPNet's accept/reject rule(s) from the
-// Filters, if there is matching rule.
+// Remove removes all net.IPNet's accept/reject rule(s) from the
+// Filters, if there are matching rules.
 //
 // Makes no distinction between whether the rule is an allow or a
 // deny.

--- a/filter_test.go
+++ b/filter_test.go
@@ -100,4 +100,24 @@ func TestFilter(t *testing.T) {
 			t.Fatalf("expected %s to be blocked", addr)
 		}
 	}
+
+	// Test removing the filter. It'll remove multiple, so make a dupe &
+	// a complement
+	f.AddAllowFilter(ipnet)
+	f.AddDialFilter(ipnet)
+
+	f.Remove(ipnet)
+	// our default is reject, so the 1.2.3.0/24 should be rejected now
+	for _, addr := range []string{
+		"/ip4/1.2.3.1/tcp/123",
+		"/ip4/4.3.3.254/udp/123",
+	} {
+		maddr, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			t.Error(err)
+		}
+		if !f.AddrBlocked(maddr) {
+			t.Fatalf("expected %s to be blocked", addr)
+		}
+	}
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -7,7 +7,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-func TestFilter(t *testing.T) {
+func TestFilterBlocking(t *testing.T) {
 	f := NewFilters()
 	for _, cidr := range []string{
 		"1.2.3.0/24",
@@ -19,6 +19,7 @@ func TestFilter(t *testing.T) {
 		f.AddDialFilter(ipnet)
 	}
 
+	// These addresses should all be blocked
 	for _, blocked := range []string{
 		"/ip4/1.2.3.4/tcp/123",
 		"/ip4/4.3.2.1/udp/123",
@@ -49,32 +50,23 @@ func TestFilter(t *testing.T) {
 			t.Fatalf("expected %s to not be blocked", addr)
 		}
 	}
+}
 
-	// test whitelisting
-	_, ipnet, _ := net.ParseCIDR("1.2.3.0/24")
-	f.AddAllowFilter(ipnet)
-	for _, addr := range []string{
-		"/ip4/1.2.3.1/tcp/123",
-		"/ip4/1.2.3.254/tcp/123",
-	} {
-		maddr, err := ma.NewMultiaddr(addr)
-		if err != nil {
-			t.Error(err)
-		}
-		if f.AddrBlocked(maddr) {
-			t.Fatalf("expected %s to be whitelisted", addr)
-		}
-	}
+func TestFilterWhitelisting(t *testing.T) {
+	f := NewFilters()
 
-	// test default-deny
-	// from above we're allowing "1.2.3.0/24
+	// Add default reject filter
 	f.RejectByDefault = true
 
-	// these are all whitelisted, should be OK
+	// Add a whitelist
+	_, ipnet, _ := net.ParseCIDR("1.2.3.0/24")
 	f.AddAllowFilter(ipnet)
+
+	// That /24 should now be allowed
 	for _, addr := range []string{
 		"/ip4/1.2.3.1/tcp/123",
 		"/ip4/1.2.3.254/tcp/123",
+		"/ip4/1.2.3.254/udp/321",
 	} {
 		maddr, err := ma.NewMultiaddr(addr)
 		if err != nil {
@@ -85,33 +77,70 @@ func TestFilter(t *testing.T) {
 		}
 	}
 
-	// these are not whitelisted, should be rejected now
-	for _, addr := range []string{
-		"/ip4/1.2.4.1/tcp/123",
-		"/ip4/4.3.2.2/udp/123",
-		"/ip6/fe00::1/tcp/321",
-		"/ip6/fc00::2/udp/321",
+	// No policy matches these maddrs, they should be blocked by default
+	for _, blocked := range []string{
+		"/ip4/1.2.4.4/tcp/123",
+		"/ip4/4.3.2.1/udp/123",
+		"/ip6/fd00::2/tcp/321",
+		"/ip6/fc00::1/udp/321",
 	} {
-		maddr, err := ma.NewMultiaddr(addr)
+		maddr, err := ma.NewMultiaddr(blocked)
 		if err != nil {
 			t.Error(err)
 		}
 		if !f.AddrBlocked(maddr) {
-			t.Fatalf("expected %s to be blocked", addr)
+			t.Fatalf("expected %s to be blocked", blocked)
+		}
+	}
+}
+
+func TestFiltersRemoveRules(t *testing.T) {
+	f := NewFilters()
+
+	ips := []string{
+		"/ip4/1.2.3.1/tcp/123",
+		"/ip4/1.2.3.254/tcp/123",
+	}
+
+	// Add default reject filter
+	f.RejectByDefault = true
+
+	// Add whitelisting
+	_, ipnet, _ := net.ParseCIDR("1.2.3.0/24")
+	f.AddAllowFilter(ipnet)
+
+	// these are all whitelisted, should be OK
+	for _, addr := range ips {
+		maddr, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			t.Error(err)
+		}
+		if f.AddrBlocked(maddr) {
+			t.Fatalf("expected %s to be whitelisted", addr)
 		}
 	}
 
 	// Test removing the filter. It'll remove multiple, so make a dupe &
 	// a complement
-	f.AddAllowFilter(ipnet)
 	f.AddDialFilter(ipnet)
 
+	// Show that they all apply, these are now blacklisted & should fail
+	for _, addr := range ips {
+		maddr, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			t.Error(err)
+		}
+		if !f.AddrBlocked(maddr) {
+			t.Fatalf("expected %s to be blacklisted", addr)
+		}
+	}
+
+	// remove those rules
 	f.Remove(ipnet)
-	// our default is reject, so the 1.2.3.0/24 should be rejected now
-	for _, addr := range []string{
-		"/ip4/1.2.3.1/tcp/123",
-		"/ip4/4.3.3.254/udp/123",
-	} {
+
+	// our default is reject, so the 1.2.3.0/24 should be rejected now,
+	// along with everything else
+	for _, addr := range ips {
 		maddr, err := ma.NewMultiaddr(addr)
 		if err != nil {
 			t.Error(err)

--- a/filter_test.go
+++ b/filter_test.go
@@ -68,7 +68,7 @@ func TestFilter(t *testing.T) {
 
 	// test default-deny
 	// from above we're allowing "1.2.3.0/24
-	f.filterDefault = true
+	f.RejectByDefault = true
 
 	// these are all whitelisted, should be OK
 	f.AddAllowFilter(ipnet)


### PR DESCRIPTION
This makes ipfs/go-ipfs#1972 possible by allowing the `Filter` to implement last-matching-term-wins policies. This allows for default-deny policies with exceptions or default-allow policies with large deny masks and selective permission in the same style as SQUID and other ACL systems.